### PR TITLE
Add incomplete invoices to admin dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < ApplicationController
   def index
     @top_customers = Customer.top_5_by_transactions
+    @incomplete_invoices = Invoice.incomplete_invoices
   end
-
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,10 +1,12 @@
 class Customer < ApplicationRecord
   has_many :invoices, dependent: :destroy
   has_many :transactions, through: :invoices
+  has_many :invoice_items, through: :invoices
+  has_many :items, through: :invoice_items
   validates_presence_of :first_name, :last_name
 
   def self.top_5_by_transactions
-    Customer.left_joins(:transactions).group(:id).where('transactions.result = ?', 'success').order(Arel.sql('COUNT(transactions.id) DESC')).limit(5)
+    Customer.left_joins(:transactions).group(:id).where('transactions.result = ?', 'success').order(Arel.sql('COUNT(transactions) DESC')).limit(5)
   end
 
   def transactions_count

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,7 @@ class Invoice < ApplicationRecord
   has_many :transactions, dependent: :destroy
   enum status: { 'in progress' => 0, completed: 1, cancelled: 2 }
 
+  def self.incomplete_invoices
+    Invoice.left_joins(:invoice_items).where.not('invoice_items.status = ?', 2).distinct.order(:updated_at)
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -4,7 +4,12 @@
   <h5>Top Customers: </h5>
 
   <% @top_customers.each do |customer| %>
-    <p id="customer_<%= customer.id %>"><%= customer.first_name %> <%= customer.last_name %> <%= customer.transactions_count %></p>
+    <p id="customer_<%= customer.id %>"><%= customer.first_name %> <%= customer.last_name %> - <%= customer.transactions_count %> purchases</p>
 
   <% end %>
-  </div>
+</div>
+<div id='incomplete_invoices'>
+  <% @incomplete_invoices.each do |invoice| %>
+    Invoice #<%= invoice.id %> - <%= invoice.updated_at.strftime('%A, %B %-d, %Y') %><br>
+  <% end %>
+</div>

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe 'admin dashboard' do
       expect(page).to have_content(9)
     end
   end
+
+  it 'Displays incomplete invoices sorted by oldest first' do
+    visit admin_path
+
+    within '#incomplete_invoices' do
+      expect('Invoice #10').to appear_before('Invoice #76')
+      expect('Invoice #76').to appear_before('Invoice #18')
+      expect('Invoice #18').to appear_before('Invoice #9')
+    end
+  end
+
+  it 'Displays dates for incomplete invoices' do
+    visit admin_path
+
+    within '#incomplete_invoices' do
+      expect(page).to have_content('Tuesday, March 6, 2012')
+    end
+  end
 end

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'merchants index' do
-end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -6,5 +6,13 @@ RSpec.describe Invoice do
     it {should have_many :invoice_items}
     it {should have_many :transactions}
     it {should have_many(:items).through(:invoice_items)}
-    end 
+  end
+
+  describe 'Class Methods' do
+    it 'returns the invoices with not shipped items in order by oldest' do
+      expect(Invoice.incomplete_invoices).to be_a ActiveRecord::Relation
+      expect(Invoice.incomplete_invoices.count).to eq 70
+      expect(Invoice.incomplete_invoices.first).to eq(Invoice.find(10))
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a section for incomplete invoices to the admin dashboard, with the invoices sorted by oldest first and the dates formatted correctly next to them